### PR TITLE
Add PAIRED-END mapping quality thrshold (MQ>=40) to match existing analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Expected unique pairs at 300M sequencing:  268938669.0
 
 We consider a library to be acceptable if:
 
-- cis pairs >1000 bp is greater than 20% of the total cis pairs.
-- Expected unique pairs at 300M sequencing is ~120 million
+- Mapped nondupe pairs cis >1000 bp is greater than 20% of the total mapped nondupe pairs.
+- Expected unique pairs at 300M sequencing is at least ~120 million

--- a/add_mate_MQ.py
+++ b/add_mate_MQ.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Add mate's MQ tags to SAM file.
+"""
+
+import sys
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    #parser.add_argument("-bam", required=True)
+    args = parser.parse_args()
+
+    current_qname = None
+    read_cache = dict()
+
+    def get_flags(line):
+        toks = line.split()
+        return int(toks[1])
+
+    def key(line):
+        toks = line.split()
+        return (toks[0], toks[2], toks[3])
+
+    def mate_key(line):
+        toks = line.split()
+        flags = get_flags(line)
+        if flags & 0x8:
+            # mate is unmapped
+            return (toks[0], "*", "*")
+        else:
+            # mate is mapped!
+            if toks[6] == "=": toks[6] = toks[2]
+            return (toks[0], toks[6], toks[7])
+
+    for line in sys.stdin:
+        line = line.strip()
+
+        if line.startswith("@"):
+            print(line)
+            continue
+
+        qkey = key(line)
+        qname = qkey[0]
+
+        if current_qname is None: current_qname = qname
+
+        if current_qname != qname:
+            # time to print this read
+            #print(">>>>>>", qname, current_qname)
+            #print(list(read_cache.keys()))
+            #print("-------------------")
+
+            for _qkey, _line in read_cache.items():
+                mkey = mate_key(_line)
+
+                first_read = read_cache[_qkey]
+                second_read = read_cache[mkey]
+
+                toks = second_read.split()
+                second_mq = int(toks[4])
+
+                print(first_read + "\t" + f"MQ:i:{second_mq}")
+            read_cache = dict()
+
+        flags = get_flags(line)
+        if flags & 0x4:
+            # read is unmapped.
+            # Note: BWA prints coords on unmapped read records 🤯
+            qkey = (qkey[0], "*", "*")
+        read_cache[qkey] = line
+        current_qname = qkey[0]

--- a/omni-c_qc.bash
+++ b/omni-c_qc.bash
@@ -6,12 +6,17 @@ fq2=$3
 out=$4
 rg=$5
 
+#get source directory
+SRCDIR=`dirname $0`
+
 bwa mem -5SP -T0 -t4 \
     -R "@RG\tID:$rg\tSM:$rg\tLB:$rg\tPL:ILLUMINA\tPU:none" \
     $ref \
     $fq1 \
     $fq2 \
+| head -n1000 \
 | samblaster -i stdin -o stdout \
+| $SRCDIR/add_mate_MQ.py \
 | samtools view -S -h -b \
 | samtools sort --threads 4 - > $out ;
 
@@ -21,19 +26,25 @@ preseq lc_extrap -B -P -e 2.1e9 -s 1e8 -seg_len 1000000000 -o $out.preseq $out
 
 ps300m=`cat $out.preseq | grep -P "^300000000.0" | awk '{print $2}'`
 
-r1=`samtools view -c -f 0x40 -F 2304 $out`
-r2=`samtools view -c -f 0x80 -F 2304 $out`
-mapped_pairs=`samtools view -c -f 0x40 -F 2316 $out`
-pcr_dupe_pairs=`samtools view -u -f 0x40 -F 2316 $out | samtools view -c -f 0x400`
-mapped_nondupe_pairs=`samtools view -c -f 0x40 -F 3340 $out`
-mapped_nondupe_pairs_cis=`samtools view -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 0) { print; }}' | wc -l`
-mapped_nondupe_pairs_cis_lt1000=`samtools view -f 0x40 -F 3340 $out | awk '{if ((sqrt($9^2) <= 1000) && ($9 != 0)) { print; }}' | wc -l`
-mapped_nondupe_pairs_cis_gt1000=`samtools view -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 1000) { print; }}' | wc -l`
-mapped_nondupe_pairs_cis_gt10000=`samtools view -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 10000) { print; }}' | wc -l`
-mapped_trans_pairs=`samtools view -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) == 0) { print; }}' | wc -l`
+qualthresh=40
+mate_filter_cmd="perl -ne 'm/MQ:i:(\\d+)/; if (\$1 >= \$ENV{qualthresh}) { print; }'"
+
+r1=`samtools view -c -q $qualthresh -f 0x40 -F 2304 $out`
+r2=`samtools view -c -q $qualthresh -f 0x80 -F 2304 $out`
+
+mapped_pairs=`samtools view -q $qualthresh -f 0x40 -F 2316 $out | eval $mate_filter_cmd | wc -l`
+pcr_dupe_pairs=`samtools view -q $qualthresh -u -f 0x40 -F 2316 $out | samtools view -c -f 0x400 | eval $mate_filter_cmd | wc -l`
+
+mapped_nondupe_pairs=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | eval $mate_filter_cmd | wc -l`
+mapped_nondupe_pairs_cis=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 0) { print; }}' | eval $mate_filter_cmd | wc -l`
+mapped_nondupe_pairs_cis_lt1000=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if ((sqrt($9^2) <= 1000) && ($9 != 0)) { print; }}' | eval $mate_filter_cmd | wc -l`
+mapped_nondupe_pairs_cis_gt1000=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 1000) { print; }}' | eval $mate_filter_cmd | wc -l`
+mapped_nondupe_pairs_cis_gt10000=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 10000) { print; }}' | eval $mate_filter_cmd | wc -l`
+mapped_trans_pairs=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) == 0) { print; }}' | eval $mate_filter_cmd | wc -l`
 
 valid_pairs=$(($mapped_nondupe_pairs_cis_gt1000 + $mapped_trans_pairs))
 
+echo "Mapping Quality Threshold         :" $qualthresh
 echo "Read1                             :" $r1
 echo "Read2                             :" $r2
 echo "Mapped pairs                      :" $mapped_pairs


### PR DESCRIPTION
Tweaks to match Lisa & Marco's analysis. 

Add PAIRED-end filtering, which necessitated adding another shell script. Sadly unavoidable but the right thing to do. 😥

Testing now on Lisa's LM1126 BAM. `s3://dtg-jared/lisasBug/LM1126.bam`

Will post results shortly. Will update readme shortly as well.

@DTGmunding, give it a test on your end too! 