### PR TITLE
Lm mq bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ Substitute appropriate file names. READGROUP name is arbitrary.
 After the script completes, it will print:
 
 ```
-Read1                             : 5417421
-Read2                             : 5417421
-Mapped pairs                      : 5400976
-PCR dupe pairs                    : 12293
-Mapped nondupe pairs              : 5388683
-Valid Pairs (cis>1000bp + trans)  : 4930332
-Mapped nondupe pairs cis          : 4090918
-Mapped nondupe pairs cis <=1000bp : 458351
-Mapped nondupe pairs cis >1000bp  : 3632567
-Mapped nondupe pairs cis >10000bp : 2751079
-Mapped nondupe trans pairs        : 1297765
-Expected unique pairs at 300M sequencing:  268938669.0
+Mapping Quality Threshold         : 40
+Read1                             : 4505616
+Read2                             : 4440232
+Mapped pairs                      : 3915274
+PCR dupe pairs                    : 9847
+Mapped nondupe pairs              : 3905427
+Valid Pairs (cis>1000bp + trans)  : 3517577
+Mapped nondupe pairs cis          : 3289426
+Mapped nondupe pairs cis <=1000bp : 387850
+Mapped nondupe pairs cis >1000bp  : 2901576
+Mapped nondupe pairs cis >10000bp : 2157962
+Mapped nondupe trans pairs        : 616001
+Expected unique pairs at 300M sequencing:  269101956.2
 ```
 
 We consider a library to be acceptable if:

--- a/omni-c_qc.bash
+++ b/omni-c_qc.bash
@@ -32,7 +32,7 @@ r1=`samtools view -c -q $qualthresh -f 0x40 -F 2304 $out`
 r2=`samtools view -c -q $qualthresh -f 0x80 -F 2304 $out`
 
 mapped_pairs=`samtools view -q $qualthresh -f 0x40 -F 2316 $out | eval $mate_filter_cmd | wc -l`
-pcr_dupe_pairs=`samtools view -q $qualthresh -u -f 0x40 -F 2316 $out | samtools view -c -f 0x400 | eval $mate_filter_cmd | wc -l`
+pcr_dupe_pairs=`samtools view -q $qualthresh -u -f 0x40 -F 2316 $out | samtools view -f 0x400 | eval $mate_filter_cmd | wc -l`
 
 mapped_nondupe_pairs=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | eval $mate_filter_cmd | wc -l`
 mapped_nondupe_pairs_cis=`samtools view -q $qualthresh -f 0x40 -F 3340 $out | awk '{if (sqrt($9^2) > 0) { print; }}' | eval $mate_filter_cmd | wc -l`

--- a/omni-c_qc.bash
+++ b/omni-c_qc.bash
@@ -14,7 +14,6 @@ bwa mem -5SP -T0 -t4 \
     $ref \
     $fq1 \
     $fq2 \
-| head -n1000 \
 | samblaster -i stdin -o stdout \
 | $SRCDIR/add_mate_MQ.py \
 | samtools view -S -h -b \

--- a/omni-c_qc.bash
+++ b/omni-c_qc.bash
@@ -26,7 +26,7 @@ preseq lc_extrap -B -P -e 2.1e9 -s 1e8 -seg_len 1000000000 -o $out.preseq $out
 ps300m=`cat $out.preseq | grep -P "^300000000.0" | awk '{print $2}'`
 
 qualthresh=40
-mate_filter_cmd="perl -ne 'm/MQ:i:(\\d+)/; if (\$1 >= \$ENV{qualthresh}) { print; }'"
+mate_filter_cmd="perl -e 'while (<STDIN>) { m/MQ:i:(\\d+)/; if (\$1 >= \$ARGV[0]) { print; }}' $qualthresh"
 
 r1=`samtools view -c -q $qualthresh -f 0x40 -F 2304 $out`
 r2=`samtools view -c -q $qualthresh -f 0x80 -F 2304 $out`


### PR DESCRIPTION
Redo of #6 (little quick on the draw with that merge there ;-) )

Tweaks to match Lisa & Marco's analysis.

Add PAIRED-end filtering, which necessitated adding another shell script. Sadly unavoidable but the right thing to do. 😥

Tested on Lisa's LM1126 BAM. s3://dtg-jared/lisasBug/LM1126.bam

Will post results shortly. Will update readme shortly as well.

@DTGmunding Give it a try on your end, but don't hit merge; I got these numbers from my alignment of your FASTQs:

```
Mapping Quality Threshold         : 40
Read1                             : 4505616
Read2                             : 4440232
Mapped pairs                      : 3915274
PCR dupe pairs                    : 9847
Mapped nondupe pairs              : 3905427
Valid Pairs (cis>1000bp + trans)  : 3517577
Mapped nondupe pairs cis          : 3289426
Mapped nondupe pairs cis <=1000bp : 387850
Mapped nondupe pairs cis >1000bp  : 2901576
Mapped nondupe pairs cis >10000bp : 2157962
Mapped nondupe trans pairs        : 616001
Expected unique pairs at 300M sequencing:  269101956.2
```
